### PR TITLE
 Tile Map for Assembly 

### DIFF
--- a/public/audio/index.js
+++ b/public/audio/index.js
@@ -509,7 +509,6 @@ window.addEventListener('copy', (event) => {
   const effect = bank.effect;
   copyBank.effect.clear();
   const selection = getSelection();
-  console.log(selection, document.activeElement);
   selection.forEach((id) => {
     copyBank.effect.push(effect.get(id));
   });

--- a/public/sprites/Tool.js
+++ b/public/sprites/Tool.js
@@ -154,8 +154,6 @@ export default class Tool {
       512 / sprites.defaultScale
     );
 
-    console.log(coords);
-
     let target = this.colour.value;
 
     if (this.selected === 'erase') {

--- a/public/sprites/index.html
+++ b/public/sprites/index.html
@@ -28,13 +28,13 @@
     </nav>
     <main>
       <div id="sprites">
-        <div>
+        <div id="download-sprites">
           <button title="[D]ownload" class="button--download has-copy"
             data-action="download">Download<br>spritesheet</button>
 
           <div class="button-group button-radio-group" id="bit-size">
             <input checked id="size-8-bit" type="radio" name="bit-size"><label for="size-8-bit"
-              class="button button-radio" data-action="8bit">8bit</label>
+              class="button button-radio" data-action="8bit" title="When switching from 4bit to 8bit, manually set all palette offsets to 0 to display colors correctly. ">8bit</label>
             <input id="size-4-bit" type="radio" name="bit-size"><label for="size-4-bit" class="button button-radio"
               data-action="4bit">4bit</label>
           </div>
@@ -463,15 +463,39 @@
                   class="current-scale"></span> tiles
                 tall</label>
             </div>
+
+            <div name="palette-reference">
+              <strong title="It is active for 4-bit sprites and 8px tiles.">Palette Reference</strong> 
+                <label title="It allows setting palette offset for each 8x8 tile.&#10;Offset information will be stored in an output map file, generating 2 bytes for a single tile.&#10;Changes in the palette do not affect the display, select palette offset in Sprite Editor to change the displayed color.">
+                <input type="checkbox" name="include-palette" id="include-palette"> include palette offset</label>
+              <div name="pal-ref-selection-div" style="display: none;"><select id="pal-ref-selection">
+                <option>0</option>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+                <option>6</option>
+                <option>7</option>
+                <option>8</option>
+                <option>9</option>
+                <option>10</option>
+                <option>11</option>
+                <option>12</option>
+                <option>13</option>
+                <option>14</option>
+                <option>15</option>
+              </select> palette offset </div>
+            </div>
+
             <div>
               <strong>Options</strong>
               <label><input type="checkbox" name="show-index-overlay"> show index overlay</label>
               <label><input type="radio" value="hatched" checked name="transparency"> hatched transparency</label>
               <label><input type="radio" value="black" name="transparency"> black for transparency</label>
               <label><input type="file" id="tile-bg"> background</label>
-              <label><input type="checkbox" checked value="3dos" id="include-tile-header" name="include-tile-header">
-                include
-                header<br><span><small>Header required if using
+              <label title="Only for BASIC"><input type="checkbox" checked value="3dos" id="include-tile-header" name="include-tile-header">
+                include header<br><span><small>Header required if using
                     <code>LOAD</code> in NextBASIC</small></span></label>
             </div>
             <span class="button input-button" id="upload-map"><input type="file">Upload map</span>

--- a/public/tools/index.js
+++ b/public/tools/index.js
@@ -440,7 +440,6 @@ param2: 0x${data.header.p2.toString(16).padStart(4, '0').toUpperCase()}`;
 }
 
 function renderBlockTable(blocks) {
-  console.log(blocks);
   tapExplore.onclick = (event) => {
     if (event.target.nodeName === 'LABEL' || event.target.nodeName === 'INPUT')
       return;


### PR DESCRIPTION
Changes in Tile Map View:
1) Hide "Download Sprites" Section
2) Support for Tile Map containing palette offset for Assembly
3) Clean asks for Sprite/Palette ID to fill up empty Tile Map
4) Tolltips with help

Please correct my writing if you wish better to understand/grammar, especially in Tooltips/Help.

I've created videos showing how it works:
https://youtu.be/USjS0AyYe74
https://youtu.be/jdq_96o4WAg

Regards,
Maciej