### PR TITLE
Palette offset support for sprites and tilemaps

### DIFF
--- a/public/audio/index.js
+++ b/public/audio/index.js
@@ -509,7 +509,6 @@ window.addEventListener('copy', (event) => {
   const effect = bank.effect;
   copyBank.effect.clear();
   const selection = getSelection();
-  console.log(selection, document.activeElement);
   selection.forEach((id) => {
     copyBank.effect.push(effect.get(id));
   });

--- a/public/sprites/SpriteSheet.js
+++ b/public/sprites/SpriteSheet.js
@@ -284,10 +284,15 @@ export default class SpriteSheet extends Hooks {
   }
 
   pget(args) {
-    return this.sprites[this._current].pget({
+    const pixel = this.sprites[this._current].pget({
       ...args,
       scale: this.defaultScale,
     });
+
+    if (this.fourBit) {
+      return pixel % 16;
+    }
+    return pixel;
   }
 
   get current() {

--- a/public/sprites/TileMap.js
+++ b/public/sprites/TileMap.js
@@ -54,6 +54,11 @@ export default class TileMap extends Hooks {
   /** @type {string} */
   filename = 'untitled.map';
 
+  /**
+   * @param {object} options
+   * @param {number} [options.size=8]
+   * @param {import("./SpriteSheet.js").default} [options.sprites]
+   */
   constructor({ size = 8, sprites }) {
     super();
     const scale = this.scale;
@@ -63,9 +68,11 @@ export default class TileMap extends Hooks {
     this.bank.fill(tileFill); //1024 / size - 1);
 
     this.palettes = new Uint8Array(bank);
-    this.palettes.fill(0); 
+    this.palettes.fill(0);
 
-    this.ctx = document.createElement('canvas').getContext('2d');
+    this.ctx = document
+      .createElement('canvas')
+      .getContext('2d', { willReadFrequently: true });
 
     const el = this.ctx.canvas;
 
@@ -99,23 +106,28 @@ export default class TileMap extends Hooks {
       height: $(`.tile-controls input[name="height"]`),
       scale: $(`.tile-controls input[name="size"]`),
       showIndex: $(`.tile-controls input[name="show-index-overlay"]`),
-      paletteReference: $(`.tile-controls div[name="palette-reference"]`),
-      paletteReferenceSelectionDiv: $(`.tile-controls div[name="pal-ref-selection-div"]`),
-      includePalette: $(`.tile-controls input[name="include-palette"]`),
+      paletteReference: $(`#palette-reference`),
+      paletteReferenceSelection: $(`.tile-controls .pal-ref-selection`),
+      includePalette: $(`#include-palette`),
+      eightBit: $('#size-8-bit'),
     };
 
     this.showIndexOverlay = this.elements.showIndex.checked;
     if (this.showIndexOverlay) this.showIndex();
 
-    document.querySelector('#pal-ref-selection').addEventListener('change', (e) => {
-      this.paletteOffset = parseInt(e.target.value, 10);
-    });
+    document
+      .querySelector('#pal-ref-selection')
+      .addEventListener('change', (e) => {
+        const offset = parseInt(e.target.value, 10);
+        this.paletteOffset = offset;
+        this.sprites.sprite.palOffset = offset;
+      });
 
     this.elements.scale.on('change', (e) => {
-      let scale = parseInt(e.target.value, 10);
+      const scale = parseInt(e.target.value, 10);
       this.tileSize = scale;
-      if(scale === 8) {
-        this.elements.paletteReference.style.display = '';
+      if (scale === 8) {
+        this.showIncludePalette();
       } else {
         this.disableIncludePalette();
       }
@@ -123,28 +135,21 @@ export default class TileMap extends Hooks {
     });
 
     this.elements.includePalette.on('change', (e) => {
-      if(e.target.checked == true){
+      if (e.target.checked == true) {
         $('#include-tile-header').checked = false;
-        
-        this.elements.paletteReferenceSelectionDiv.style.display = '';
+
+        this.elements.paletteReferenceSelection.style.display = '';
         $('#size-4-bit').checked = true;
         $('#size-8-bit').checked = false;
         this.paletteOffset = 0;
         document.querySelector('#pal-ref-selection').value = 0;
       } else {
-        this.elements.paletteReferenceSelectionDiv.style.display = 'none';
+        this.elements.paletteReferenceSelection.style.display = 'none';
         this.paletteOffset = -1;
       }
     });
 
-    $('#bit-size').on('change', () => {
-      if($('#size-8-bit').checked == true) {
-        this.disableIncludePalette();
-
-      } else if($('#size-4-bit').checked == true && this.size == 8) {
-        this.elements.paletteReference.style.display = '';
-      }
-    });
+    $('#bit-size').on('change', () => this.updateIncludePaletteUI());
 
     $('.tile-controls input').on('change', () => {
       this.resize({
@@ -168,6 +173,8 @@ export default class TileMap extends Hooks {
 
     // triggers dom changes
     this.setDimensions({ width: w, height: h, size });
+    this.updateIncludePaletteUI();
+
     this.snapshot();
   }
 
@@ -182,12 +189,26 @@ export default class TileMap extends Hooks {
     }
   }
 
-  disableIncludePalette(){
-    $('#include-palette').checked = false;
+  updateIncludePaletteUI() {
+    console.log({ size: this.size, checked: this.elements.eightBit.checked });
+    if (this.size === 8 && this.elements.eightBit.checked == false) {
+      this.showIncludePalette();
+    } else {
+      this.disableIncludePalette();
+    }
+  }
+
+  disableIncludePalette() {
+    this.elements.includePalette.checked = false;
     this.elements.includePalette.value = false;
-    this.elements.paletteReferenceSelectionDiv.style.display = 'none';
+    this.elements.paletteReferenceSelection.style.display = 'none';
     this.elements.paletteReference.style.display = 'none';
     this.paletteOffset = -1;
+  }
+
+  showIncludePalette() {
+    this.elements.paletteReferenceSelection.style.display = '';
+    this.elements.paletteReference.style.display = '';
   }
 
   clear(newTileFill = tileFill, newPaletteFill = paletteFill) {
@@ -198,7 +219,7 @@ export default class TileMap extends Hooks {
     bank.fill(tileFill);
 
     const palettes = new Uint8Array(this.width * this.height);
-    palettes.fill(paletteFill); 
+    palettes.fill(paletteFill);
 
     this.load({ bank, palettes });
     this.paint();
@@ -235,6 +256,7 @@ export default class TileMap extends Hooks {
     return {
       bank: Array.from(this.bank),
       palettes: Array.from(this.palettes),
+      includePal: this.elements.includePalette.checked,
       filename: this.filename,
       scale: this.scale,
       width: this.width,
@@ -300,7 +322,7 @@ export default class TileMap extends Hooks {
 
     // max bank size: 16k
     const bank = new Uint8Array(w * h);
-    bank.fill(tileFill); 
+    bank.fill(tileFill);
 
     if (w !== width) {
       const adjust = w > width ? width : w;
@@ -331,14 +353,17 @@ export default class TileMap extends Hooks {
     this.paint();
   }
 
+  /**
+   * @returns {import("./SpriteSheet.js").default}
+   */
   get sprites() {
     return this._sprites;
   }
 
   load({ bank, dimensions = {}, sprites = null, palettes = null }) {
     if (Object.keys(dimensions).length) this.setDimensions(dimensions);
-    if(palettes) {
-        this.palettes = palettes;
+    if (palettes) {
+      this.palettes = palettes;
     }
     this.history = [];
     this.bank = bank;
@@ -360,13 +385,13 @@ export default class TileMap extends Hooks {
   set(index) {
     if (this._lastSet !== index) {
       this.bank[index] = this.sprites.spriteIndex(this.size);
-      if(this.paletteOffset > 0) {
+      if (this.paletteOffset > 0) {
         this.palettes[index] = this.paletteOffset;
-      }    
+      }
       this.snapshot();
       this._lastSet = index;
       this.trigger();
-      this.paintSingle(index);
+      this.paintSingle(index, null, this.palettes[index]); // clearing?
     }
   }
 
@@ -375,7 +400,8 @@ export default class TileMap extends Hooks {
       const index = this._tmp;
       currentTile.innerHTML = `&nbsp;`;
 
-      this.paintSingle(index);
+      window.paintPal = this.palettes[index];
+      this.paintSingle(index, null, this.palettes[index]);
       this._tmp = null;
     }
   }
@@ -396,10 +422,10 @@ export default class TileMap extends Hooks {
 
     this._tmp = index;
 
-    if (index !== null) {    
+    if (index !== null) {
       currentTile.innerHTML = `X:${x} Y:${y} #${this.bank[index]} @${index}`;
-      if($('#include-palette').checked == true) {
-        currentTile.innerHTML += ` Palette:${this.palettes[index]}`
+      if (this.elements.includePalette.checked == true) {
+        currentTile.innerHTML += ` Palette:${this.palettes[index]}`;
       }
     } else {
       currentTile.innerHTML = '';
@@ -425,7 +451,7 @@ export default class TileMap extends Hooks {
     return str;
   }
 
-  paintSingle(i, bankIndex = null) {
+  paintSingle(i, bankIndex = null, palOffset) {
     const small = this.size === 8;
     const { x, y } = this.getXY(i);
     if (bankIndex === null) bankIndex = this.bank[i];
@@ -447,6 +473,7 @@ export default class TileMap extends Hooks {
       x: x * this.size * this.scale,
       y: y * this.size * this.scale,
       w: this.size * this.scale,
+      palOffset,
     });
   }
 
@@ -474,6 +501,7 @@ export default class TileMap extends Hooks {
         x: x * this.size * this.scale,
         y: y * this.size * this.scale,
         w: this.size * this.scale,
+        palOffset: this.palettes[i],
       });
     }
   }

--- a/public/sprites/Tool.js
+++ b/public/sprites/Tool.js
@@ -154,8 +154,6 @@ export default class Tool {
       512 / sprites.defaultScale
     );
 
-    console.log(coords);
-
     let target = this.colour.value;
 
     if (this.selected === 'erase') {

--- a/public/sprites/index.html
+++ b/public/sprites/index.html
@@ -28,13 +28,13 @@
     </nav>
     <main>
       <div id="sprites">
-        <div>
+        <div id="download-sprites">
           <button title="[D]ownload" class="button--download has-copy"
             data-action="download">Download<br>spritesheet</button>
 
           <div class="button-group button-radio-group" id="bit-size">
             <input checked id="size-8-bit" type="radio" name="bit-size"><label for="size-8-bit"
-              class="button button-radio" data-action="8bit">8bit</label>
+              class="button button-radio" data-action="8bit" title="When switching from 4bit to 8bit, manually set all palette offsets to 0 to display colors correctly. ">8bit</label>
             <input id="size-4-bit" type="radio" name="bit-size"><label for="size-4-bit" class="button button-radio"
               data-action="4bit">4bit</label>
           </div>
@@ -463,15 +463,39 @@
                   class="current-scale"></span> tiles
                 tall</label>
             </div>
+
+            <div name="palette-reference">
+              <strong title="It is active for 4-bit sprites and 8px tiles.">Palette Reference</strong> 
+                <label title="It allows setting palette offset for each 8x8 tile.&#10;Offset information will be stored in an output map file, generating 2 bytes for a single tile.&#10;Changes in the palette do not affect the display, select palette offset in Sprite Editor to change the displayed color.">
+                <input type="checkbox" name="include-palette" id="include-palette"> include palette offset</label>
+              <div name="pal-ref-selection-div" style="display: none;"><select id="pal-ref-selection">
+                <option>0</option>
+                <option>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+                <option>5</option>
+                <option>6</option>
+                <option>7</option>
+                <option>8</option>
+                <option>9</option>
+                <option>10</option>
+                <option>11</option>
+                <option>12</option>
+                <option>13</option>
+                <option>14</option>
+                <option>15</option>
+              </select> palette offset </div>
+            </div>
+
             <div>
               <strong>Options</strong>
               <label><input type="checkbox" name="show-index-overlay"> show index overlay</label>
               <label><input type="radio" value="hatched" checked name="transparency"> hatched transparency</label>
               <label><input type="radio" value="black" name="transparency"> black for transparency</label>
               <label><input type="file" id="tile-bg"> background</label>
-              <label><input type="checkbox" checked value="3dos" id="include-tile-header" name="include-tile-header">
-                include
-                header<br><span><small>Header required if using
+              <label title="Only for BASIC"><input type="checkbox" checked value="3dos" id="include-tile-header" name="include-tile-header">
+                include header<br><span><small>Header required if using
                     <code>LOAD</code> in NextBASIC</small></span></label>
             </div>
             <span class="button input-button" id="upload-map"><input type="file">Upload map</span>

--- a/public/sprites/index.html
+++ b/public/sprites/index.html
@@ -34,7 +34,8 @@
 
           <div class="button-group button-radio-group" id="bit-size">
             <input checked id="size-8-bit" type="radio" name="bit-size"><label for="size-8-bit"
-              class="button button-radio" data-action="8bit" title="When switching from 4bit to 8bit, manually set all palette offsets to 0 to display colors correctly. ">8bit</label>
+              class="button button-radio" data-action="8bit"
+              title="When switching from 4bit to 8bit, manually set all palette offsets to 0 to display colors correctly. ">8bit</label>
             <input id="size-4-bit" type="radio" name="bit-size"><label for="size-4-bit" class="button button-radio"
               data-action="4bit">4bit</label>
           </div>
@@ -464,28 +465,29 @@
                 tall</label>
             </div>
 
-            <div name="palette-reference">
-              <strong title="It is active for 4-bit sprites and 8px tiles.">Palette Reference</strong> 
-                <label title="It allows setting palette offset for each 8x8 tile.&#10;Offset information will be stored in an output map file, generating 2 bytes for a single tile.&#10;Changes in the palette do not affect the display, select palette offset in Sprite Editor to change the displayed color.">
+            <div id="palette-reference">
+              <strong>Palette Reference</strong>
+              <label
+                title="The palette offset will be stored in the output map file, generating 2 bytes for a single tile.">
                 <input type="checkbox" name="include-palette" id="include-palette"> include palette offset</label>
-              <div name="pal-ref-selection-div" style="display: none;"><select id="pal-ref-selection">
-                <option>0</option>
-                <option>1</option>
-                <option>2</option>
-                <option>3</option>
-                <option>4</option>
-                <option>5</option>
-                <option>6</option>
-                <option>7</option>
-                <option>8</option>
-                <option>9</option>
-                <option>10</option>
-                <option>11</option>
-                <option>12</option>
-                <option>13</option>
-                <option>14</option>
-                <option>15</option>
-              </select> palette offset </div>
+              <div class="pal-ref-selection" style="display: none;"><select id="pal-ref-selection">
+                  <option>0</option>
+                  <option>1</option>
+                  <option>2</option>
+                  <option>3</option>
+                  <option>4</option>
+                  <option>5</option>
+                  <option>6</option>
+                  <option>7</option>
+                  <option>8</option>
+                  <option>9</option>
+                  <option>10</option>
+                  <option>11</option>
+                  <option>12</option>
+                  <option>13</option>
+                  <option>14</option>
+                  <option>15</option>
+                </select> palette offset </div>
             </div>
 
             <div>
@@ -494,8 +496,9 @@
               <label><input type="radio" value="hatched" checked name="transparency"> hatched transparency</label>
               <label><input type="radio" value="black" name="transparency"> black for transparency</label>
               <label><input type="file" id="tile-bg"> background</label>
-              <label title="Only for BASIC"><input type="checkbox" checked value="3dos" id="include-tile-header" name="include-tile-header">
-                include header<br><span><small>Header required if using
+              <label title="Only for BASIC"><input type="checkbox" checked value="3dos" id="include-tile-header"
+                  name="include-tile-header">
+                NextBASIC header<br><span><small>Header required if using
                     <code>LOAD</code> in NextBASIC</small></span></label>
             </div>
             <span class="button input-button" id="upload-map"><input type="file">Upload map</span>

--- a/public/sprites/index.js
+++ b/public/sprites/index.js
@@ -1075,9 +1075,10 @@ $('#tile-bg').on('change', (e) => {
   canvas.style.backgroundSize = '100%';
 });
 
-fourBitPalPicker.addEventListener('click', (e) => {
-  const base = parseInt(e.target.textContent, 16);
-  fourBitPalSelected.value = base;
+/**
+ * @param {number} base
+ */
+function updatePaletteSelection(base) {
   palette.node.parentNode.dataset.pal = base;
   sprites.sprite.palOffset = base;
   const pixels = sprites.sprite.pixels;
@@ -1086,17 +1087,17 @@ fourBitPalPicker.addEventListener('click', (e) => {
     pixels[i] = root + 16 * base;
   });
   sprites.paintAll();
+}
+
+fourBitPalPicker.addEventListener('click', (e) => {
+  const base = parseInt(e.target.textContent, 16);
+  fourBitPalSelected.value = base;
+  updatePaletteSelection(base);
 });
 fourBitPalSelected.addEventListener('change', () => {
   // change all the sprite preview values to X
   const base = parseInt(fourBitPalSelected.value, 10);
-  palette.node.parentNode.dataset.pal = base;
-  const pixels = sprites.sprite.pixels;
-  pixels.forEach((value, i) => {
-    const root = value & 15; // effectively mod 16
-    pixels[i] = root + 16 * base;
-  });
-  sprites.paintAll();
+  updatePaletteSelection(base);
 });
 
 function downloadPal() {

--- a/public/sprites/index.js
+++ b/public/sprites/index.js
@@ -389,12 +389,34 @@ function fileToTile(data, file) {
 
   const dimensions = {};
   let bank = null;
+  let palettes = undefined;
   if (header.sig !== 'PLUS3DOS') {
-    const dims = prompt('Tile map width?');
-    const width = parseInt(dims.trim(), 10);
-    dimensions.width = width; // aka autostart
-    dimensions.height = data.length / width;
-    bank = new Uint8Array(data);
+    const dimW = prompt('Tile map width?');
+
+    if (dimW === null) {
+      return;
+    }
+
+    const dimH = prompt('Tile map height?');
+
+    if (dimH === null) {
+      return;
+    }
+    const width = parseInt(dimW.trim(), 10);
+    const height = parseInt(dimH.trim(), 10);
+
+    dimensions.width = width;
+    dimensions.height = height;
+
+    if (data.length === width * height * 2) {
+      // then we have a palette
+      palettes = new Uint8Array(
+        data.filter((_, i) => i % 2 === 1).map((_) => _ >> 4)
+      );
+      bank = new Uint8Array(data.filter((_, i) => i % 2 === 0));
+    } else {
+      bank = new Uint8Array(data.filter((_, i) => i % 2 === 0));
+    }
   } else if (header.hOffset !== 0x8000) {
     // then we've got a version where I tucked the dimensions in the file
     dimensions.width = header.autostart; // aka autostart
@@ -404,7 +426,7 @@ function fileToTile(data, file) {
     bank = new Uint8Array(data.slice(unpack.offset));
   }
   tileMap.filename = file.name;
-  tileMap.load({ bank, dimensions });
+  tileMap.load({ bank, dimensions, palettes });
   tileMap.sprites = sprites; // just in case
   tileMap.paint();
 }

--- a/public/tools/index.js
+++ b/public/tools/index.js
@@ -440,7 +440,6 @@ param2: 0x${data.header.p2.toString(16).padStart(4, '0').toUpperCase()}`;
 }
 
 function renderBlockTable(blocks) {
-  console.log(blocks);
   tapExplore.onclick = (event) => {
     if (event.target.nodeName === 'LABEL' || event.target.nodeName === 'INPUT')
       return;


### PR DESCRIPTION
Original PR by @maciejmiklas:

Changes in Tile Map View:

- Hide "Download Sprites" Section
- Support for Tile Map containing palette offset for Assembly
- Clean asks for Sprite/Palette ID to fill up empty Tile Map
- Tolltips with help

I've created videos showing how it works:
[youtu.be/USjS0AyYe74](https://youtu.be/USjS0AyYe74)
[youtu.be/jdq_96o4WAg](https://youtu.be/jdq_96o4WAg)

---

Remy has added the following support:

- Update tile map canvas to use the selected palette (thus giving a better preview of the final result)
- Restore palette from .map uploaded file
- Fixed 4-bit sprite hover info, so it shows the 16 byte palette value
